### PR TITLE
3) Feature - Database Redesign

### DIFF
--- a/server/db/models/group.js
+++ b/server/db/models/group.js
@@ -1,0 +1,13 @@
+const db = require("../db");
+const Sequelize = require("sequelize");
+
+const Group = db.define("group", {
+  name: {
+    type: Sequelize.STRING,
+  },
+  photoUrl: {
+    type: Sequelize.STRING,
+  },
+});
+
+module.exports = Group;

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -15,7 +15,6 @@ Message.belongsTo(Conversation);
 Conversation.hasMany(Message);
 
 Group.belongsTo(Conversation);
-Conversation.hasMany(Group);
 
 UserGroup.belongsTo(Group);
 Group.hasMany(UserGroup);

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -1,17 +1,31 @@
 const Conversation = require("./conversation");
 const User = require("./user");
 const Message = require("./message");
+const Group = require("./group");
+const UserGroup = require("./user_group");
 
 // associations
 
 User.hasMany(Conversation);
+
 Conversation.belongsTo(User, { as: "user1" });
 Conversation.belongsTo(User, { as: "user2" });
+
 Message.belongsTo(Conversation);
 Conversation.hasMany(Message);
+
+Group.belongsTo(Conversation);
+Conversation.hasMany(Group);
+
+UserGroup.belongsTo(Group);
+Group.hasMany(UserGroup);
+
+UserGroup.belongsTo(User);
+User.hasMany(UserGroup);
 
 module.exports = {
   User,
   Conversation,
-  Message
+  Message,
+  Group,
 };

--- a/server/db/models/user_group.js
+++ b/server/db/models/user_group.js
@@ -1,0 +1,5 @@
+const db = require("../db");
+
+const UserGroup = db.define("user_group", {});
+
+module.exports = UserGroup;

--- a/server/db/seed.js
+++ b/server/db/seed.js
@@ -1,7 +1,8 @@
 const db = require("./db");
-const { User } = require("./models");
+const { User, Group } = require("./models");
 const Conversation = require("./models/conversation");
 const Message = require("./models/message");
+const UserGroup = require("./models/user_group");
 
 async function seed() {
   await db.sync({ force: true });
@@ -114,6 +115,78 @@ async function seed() {
   ]);
 
   console.log(`seeded users and messages`);
+
+  const groupConversations = await Promise.all([
+    Conversation.create({}),
+    Conversation.create({}),
+    Conversation.create({}),
+  ]);
+
+  const groups = await Promise.all(
+    groupConversations.map((convo, index) => {
+      return Group.create({
+        name: `Group ${index + 1}`,
+        conversationId: convo.id,
+      });
+    })
+  );
+
+  const userGroups = await Promise.all([
+    UserGroup.create({
+      groupId: groups[0].id,
+      userId: thomas.id,
+    }),
+    UserGroup.create({
+      groupId: groups[1].id,
+      userId: thomas.id,
+    }),
+    UserGroup.create({
+      groupId: groups[1].id,
+      userId: santiago.id,
+    }),
+    UserGroup.create({
+      groupId: groups[2].id,
+      userId: santiago.id,
+    }),
+    UserGroup.create({
+      groupId: groups[2].id,
+      userId: chiumbo.id,
+    }),
+    UserGroup.create({
+      groupId: groups[0].id,
+      userId: hualing.id,
+    }),
+  ]);
+
+  const groupMessages = await Promise.all([
+    Message.create({
+      conversationId: groupConversations[0].id,
+      senderId: thomas.id,
+      text: "Hii",
+    }),
+    Message.create({
+      conversationId: groupConversations[1].id,
+      senderId: thomas.id,
+      text: "Hello",
+    }),
+    Message.create({
+      conversationId: groupConversations[2].id,
+      senderId: santiago.id,
+      text: "Hey, There",
+    }),
+    Message.create({
+      conversationId: groupConversations[0].id,
+      senderId: hualing.id,
+      text: "How are you?",
+    }),
+    Message.create({
+      conversationId: groupConversations[1].id,
+      senderId: thomas.id,
+      text: "Hey",
+    }),
+  ]);
+
+  console.log(`seeded groups`);
 }
 
 async function runSeed() {


### PR DESCRIPTION
To plan out this solution we will create two more models, Group and UserGroup. Each Group will know linked conversation and each UserGroup will link user with group. For the message send to the group we keep user1Id and  user2Id null and we will link new conversation to the group. so this way we can make join for messages, conversation, groups and  userGroups.

Having two separate  table also help us adding more functionality  like group admins, group members, group name, group pictures, etc.

Please check database model  for more information.

To keep things  simple and avoid bugs we can have new server side api for group conversations. everything related to  groups will be handled in different route. We can also have server side validation to enforce database rules for group message creation and filter group messages.

If  our app is  already deployed, we could create separate micro service for group chat. We can release it for few users and if it  works fine then  we can release it gradually. since we are not making changes to the existing database schema for two person chat, our system should run smoothly.

We can even shard database if there is too much load on server by splitting group system in different database.

![group  chat](https://user-images.githubusercontent.com/48192560/129522111-1f2c0065-2ac0-4e37-a699-343b4302012f.PNG)
