### PR TITLE
Feature read receipts alternative approch. 

### DIFF
--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -123,7 +123,7 @@ export const sendReadReceipt = (body) => async (dispatch) => {
   try {
     const { conversationId, senderId } = body;
     const { data } = await axios.patch(`/api/conversations/read/${senderId}`); //  update database first.
-    dispatch(resetNotification(conversationId)); // update my last read
+    dispatch(resetNotification(conversationId)); // reset notification for current user.
 
     // emit message-read to notify other user.
     socket.emit("message-read", {


### PR DESCRIPTION
Added feature read receipt for message sender.
Counting notification for message receiver.

I have implemented read status as per your suggestion. now each message will know if it was read by other user or not.

However,  there is disadvantage of this approach. Lets say we introduce group chat in future and we want to allow sender to see if the message  is read by all recipient or not. Now, It will be harder to implement this features. we might have to redesign the schema to accommodate this. 

Also, if the service is already deployed, releasing feature will also be hard.


![New Message Sent](https://user-images.githubusercontent.com/48192560/129700704-c7131e09-7b1e-4d15-b1b9-3e0fae0e9fc2.PNG)
![Read Receipt Sent](https://user-images.githubusercontent.com/48192560/129700699-e4985fe0-451d-437a-8536-de49d8a6dac8.PNG)

![New Message Sent 2](https://user-images.githubusercontent.com/48192560/129700701-58fe1fcb-06c2-4483-8db2-82f9484720b5.PNG)
![Read Receipt Sent 2](https://user-images.githubusercontent.com/48192560/129700696-7cadb706-2cca-451a-93a4-f6c36bba26e5.PNG)

